### PR TITLE
Complete code coverage for PrimaryCleanPipeline

### DIFF
--- a/Is This Vegan - API/Is This Vegan (Net)/Backend/Ingredient List/PrimaryCleanPipeline.cs
+++ b/Is This Vegan - API/Is This Vegan (Net)/Backend/Ingredient List/PrimaryCleanPipeline.cs
@@ -41,7 +41,7 @@ namespace Is_This_Vegan__Net_.Backend.Ingredient_List
             {
                 result = new PipelineResultModel();
                 result.isSuccessful = false;
-                result.result = e.ToString();
+                result.result = e.Message;
             }
 
             return result;
@@ -66,7 +66,7 @@ namespace Is_This_Vegan__Net_.Backend.Ingredient_List
                 meanConfidence is null ||
                 float.IsNaN((float)meanConfidence))
             {
-                return new PipelineResultModel() { isSuccessful = false, result = "" };
+                throw new ArgumentException("Ingredient list must be longer than 1 character and text extraction confidence must be over 70%.");
             }
             else if (meanConfidence <= 70.00) 
             {


### PR DESCRIPTION
Code coverage is as close to 100% as possible. There is an
under-the-hood oddity that will not let me achieve 100% code coverage
due to the statement:
'else if (meanConfidence <= 70.00)'

For more information on this one can see the example in this online
forum: https://social.msdn.microsoft.com/Forums/en-US/5f7eb318-9ca4-4914-b6a5-7447f4b98ce8/partially-touched-code-question

Also added an ArgumentException throw to my test case to cover the
try-catch block in Execute function.